### PR TITLE
Update Node.js version in legacy installation example

### DIFF
--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -103,8 +103,8 @@ best-efforts basis with the following warnings:
 Client libraries targeting some end-of-life versions of Node.js are available, and
 can be installed through npm [dist-tags](https://docs.npmjs.com/cli/dist-tag).
 The dist-tags follow the naming convention `legacy-(version)`.
-For example, `{{ metadata['lib_install_cmd'] }}@legacy-8` installs client libraries
-for versions compatible with Node.js 8.
+For example, `{{ metadata['lib_install_cmd'] }}@legacy-10` installs client libraries
+for versions compatible with Node.js 10.
 
 ## Versioning
 


### PR DESCRIPTION
Update version from 8 to 10 in the legacy installation example because Node.js 10 will be going into maintenance mode for the Google Cloud Node.js SDK on March 31, 2022.

Edit: Please hold this request until bcoe has a chance to review. Thanks. 